### PR TITLE
If an extra configuration script exists, use it for provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_STORE
 .vagrant
+extra-configuration.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,4 +8,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "scotchbox"
   config.vm.synced_folder ".", "/var/www", :mount_options => ["dmode=777", "fmode=666"]
 
+  if File.exist?("extra-configuration.sh")
+    config.vm.provision "shell", path: "extra-configuration.sh"
+  end
 end


### PR DESCRIPTION
This way, every configuration option doesn't need to go into the scotch box repo. Projects can run their own special configuration if it's required.