### PR TITLE
Update index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -434,7 +434,7 @@
                     <table class="table table-responsive table-striped table-hover">
                         <tr>
                             <td>SSH Host</td>
-                            <td><?php echo $_SERVER['REMOTE_ADDR']; ?></td>
+                            <td><?php echo $_SERVER['SERVER_ADDR']; ?></td>
                         </tr>
                         <tr>
                             <td>SSH User</td>


### PR DESCRIPTION
I've found that the section SSH Credentials might show the client IP instead of the server IP. (defaults to 192.168.33.10)

Another fix that could work:
 $ipAddress = gethostbyname($_SERVER['SERVER_NAME']);

'REMOTE_ADDR' is The IP address from which the user is viewing the current page. 
'SERVER_ADDR' The IP address of the server under which the current script is executing. 
source: http://php.net/manual/en/reserved.variables.server.php
Thanks