### PR TITLE
Adding provision file to update PHP 5.6 PPA and packages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,9 @@ Vagrant.configure("2") do |config|
     config.vm.network "private_network", ip: "192.168.33.10"
     config.vm.hostname = "scotchbox"
     config.vm.synced_folder ".", "/var/www", :mount_options => ["dmode=777", "fmode=666"]
+    config.vm.provision "provision", type: :shell, path: "provision/update-php56.sh"
+    # Optional - Update all system packages, uncomment below to enable
+    # config.vm.provision "provision", type: :shell, path: "provision/update.sh"
     
     # Optional NFS. Make sure to remove other synced_folder line too
     #config.vm.synced_folder ".", "/var/www", :nfs => { :mount_options => ["dmode=777","fmode=666"] }

--- a/provision/update-php56.sh
+++ b/provision/update-php56.sh
@@ -30,7 +30,7 @@ echo "============================================"
 sudo apt-get install libapache2-mod-php5.6 -y
 sudo apt-get install php5.6 php5.6-cgi php5.6-cli php5.6-common php5.6-curl php5.6-fpm php5.6-gd \
 php5.6-intl php5.6-mcrypt php5.6-memcache php5.6-memcached php5.6-mongo php5.6-mysqlnd php5.6-pgsql \
-php5.6-readline php5.6-redis php5.6-sqlite php5.6-mbstring php5.6-zip php5.6-json php5.6-xdebug php-imagick -y
+php5.6-readline php5.6-redis php5.6-sqlite php5.6-mbstring php5.6-zip php5.6-json php5.6-xdebug php5.6-xml php-imagick -y
 sudo a2dismod php5
 sudo a2enmod php5.6
 # uninstall old php5 packages

--- a/provision/update-php56.sh
+++ b/provision/update-php56.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+apt-get()
+{
+	DEBIAN_FRONTEND=noninteractive command apt-get \
+    -o Dpkg::Options::="--force-confdef" \
+    -o Dpkg::Options::="--force-confold" \
+    "$@"
+}
+
+# Disable obsolete PPA
+echo "============================================"
+echo "Disabling and deleting obsolete PPA."
+echo "============================================"
+# sudo apt-get install ppa-purge
+# sudo ppa-purge ppa:ondrej/php5-5.6
+sudo add-apt-repository --remove ppa:ondrej/php5-5.6 -y
+# Force incase
+sudo rm /etc/apt/sources.list.d/ondrej-php5-5_6-trusty.list
+# Update to current PPA
+echo "============================================"
+echo "Adding current PPA and updating packages."
+echo "============================================"
+sudo add-apt-repository ppa:ondrej/php -y
+sudo apt-get update
+# Install PHP 5.6 Packages
+echo "============================================"
+echo "Installing PHP 5.6 and common packages."
+echo "============================================"
+sudo apt-get install libapache2-mod-php5.6 -y
+sudo apt-get install php5.6 php5.6-cgi php5.6-cli php5.6-common php5.6-curl php5.6-fpm php5.6-gd \
+php5.6-intl php5.6-mcrypt php5.6-memcache php5.6-memcached php5.6-mongo php5.6-mysqlnd php5.6-pgsql \
+php5.6-readline php5.6-redis php5.6-sqlite php5.6-mbstring php5.6-zip php5.6-json php5.6-xdebug php-imagick -y
+sudo a2dismod php5
+sudo a2enmod php5.6
+# uninstall old php5 packages
+sudo apt-get autoremove
+sudo apt-get --purge remove php5-common php5-json php5-imagick -y
+# Clean up Apt
+sudo apt-get clean
+# Configure Xdebug
+echo "============================================"
+echo "Configure Xdebug."
+echo "============================================"
+echo "; xdebug
+zend_extension=xdebug.so
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9000
+xdebug.remote_host=192.168.33.10" >> /etc/php5/apache2/conf.d/20-xdebug.ini
+# add composer to path
+echo "============================================"
+echo "Adding composer to PATH."
+echo "============================================"
+export PATH="~/.composer/vendor/bin:$PATH"
+# restart Apache
+echo "============================================"
+echo "Restarting Apache and PHP-FPM."
+sudo service apache2 restart
+sudo service php5.6-fpm restart
+echo "============================================"
+echo "============================================"
+echo "Provision complete."
+echo "============================================"

--- a/provision/update.sh
+++ b/provision/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+apt-get()
+{
+	DEBIAN_FRONTEND=noninteractive command apt-get \
+    -o Dpkg::Options::="--force-confdef" \
+    -o Dpkg::Options::="--force-confold" \
+    "$@"
+}
+
+# Optional
+echo "============================================"
+echo "Upgrading all system packages and kernel, this may take a while."
+echo "============================================"
+sudo apt-get upgrade -y
+sudo apt-get clean
+sudo reboot


### PR DESCRIPTION
Pending a proper vagrant box update I propose adding this provision script to update the PHP PPA repo and package due to the currently installed PPA packages being broken as referenced in issue: #273 

I took the liberty of extending what @smutek had done with his provision script and made a few adjustments.

What does this do?
- Removes and deletes obsolete and broken PPA 
> ppa:ondrej/php5-5.6
- Add correct PHP PPA
> ppa:ondrej/php
- Installs latest common PHP 5.6 packages
- Removes old PHP packages that were previously installed
- Configures Xdebug and adds composer to the PATH ENV var
- Restarts Web Services
- Optionally (left out for quicker deploy if you're not concerned with updates) you can enable updating all system packages by uncommenting the following line in the Vagrantfile: 
`# Optional - Update all system packages, uncomment below to enable`
`# config.vm.provision "provision", type: :shell, path: "provision/update.sh"`

Updates were also based off recommended process here: [https://github.com/oerdnj/deb.sury.org/wiki/PPA-migration-to-ppa:ondrej-php](https://github.com/oerdnj/deb.sury.org/wiki/PPA-migration-to-ppa:ondrej-php)